### PR TITLE
fix createApolloLink correct return type :rocket:

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground.tsx
+++ b/packages/graphql-playground-react/src/components/Playground.tsx
@@ -8,7 +8,6 @@ import Settings from './Settings'
 import { PlaygroundSettingsEditor, GraphQLConfigEditor } from './SettingsEditor'
 import { GraphQLConfig } from '../graphqlConfig'
 import FileEditor from './FileEditor'
-import { ApolloLink } from 'apollo-link'
 
 import * as app from '../../package.json'
 import { connect } from 'react-redux'
@@ -44,8 +43,8 @@ import {
   setLinkCreator,
   schemaFetcher,
   setSubscriptionEndpoint,
+  LinkAndSubscriptionGetter,
 } from '../state/sessions/fetchingSagas'
-import { Session } from '../state/sessions/reducers'
 import { getWorkspaceId } from './Playground/util/getWorkspaceId'
 import { getSettings, getSettingsString } from '../state/workspace/reducers'
 import { Backoff } from './Playground/util/fibonacci-backoff'
@@ -86,10 +85,7 @@ export interface Props {
   fixedEndpoints: boolean
   headers?: any
   configPath?: string
-  createApolloLink?: (
-    session: Session,
-    subscriptionEndpoint?: string,
-  ) => ApolloLink
+  createApolloLink?: LinkAndSubscriptionGetter
   workspaceName?: string
   schema?: GraphQLSchema
 }

--- a/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
+++ b/packages/graphql-playground-react/src/components/PlaygroundWrapper.tsx
@@ -22,10 +22,10 @@ import { getActiveEndpoints } from './util'
 import { ISettings } from '../types'
 import { connect } from 'react-redux'
 import { getTheme, getSettings } from '../state/workspace/reducers'
-import { Session, Tab } from '../state/sessions/reducers'
-import { ApolloLink } from 'apollo-link'
+import { Tab } from '../state/sessions/reducers'
 import { injectTabs } from '../state/workspace/actions'
 import { buildSchema, buildClientSchema, GraphQLSchema } from 'graphql'
+import { LinkAndSubscriptionGetter } from '../state/sessions/fetchingSagas'
 
 function getParameterByName(name: string, uri?: string): string | null {
   const url = uri || window.location.href
@@ -59,10 +59,7 @@ export interface PlaygroundWrapperProps {
   config?: GraphQLConfig
   configPath?: string
   injectedState?: any
-  createApolloLink?: (
-    session: Session,
-    subscriptionEndpoint?: string,
-  ) => ApolloLink
+  createApolloLink?: LinkAndSubscriptionGetter
   tabs?: Tab[]
   schema?: { __schema: any } // introspection result
   codeTheme?: EditorColours

--- a/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
+++ b/packages/graphql-playground-react/src/state/sessions/fetchingSagas.ts
@@ -56,7 +56,12 @@ export interface Headers {
   [key: string]: string | number | null
 }
 
-export const defaultLinkCreator = (
+export type LinkAndSubscriptionGetter = (
+  session: LinkCreatorProps,
+  subscriptionEndpoint?: string,
+) => { link: ApolloLink; subscriptionClient?: SubscriptionClient }
+
+export const defaultLinkCreator: LinkAndSubscriptionGetter = (
   session: LinkCreatorProps,
   subscriptionEndpoint?: string,
 ): { link: ApolloLink; subscriptionClient?: SubscriptionClient } => {
@@ -94,11 +99,13 @@ export const defaultLinkCreator = (
   }
 }
 
-let linkCreator = defaultLinkCreator
+let linkCreator: LinkAndSubscriptionGetter = defaultLinkCreator
 export let schemaFetcher: SchemaFetcher = new SchemaFetcher(linkCreator)
 ;(window as any).schemaFetcher = schemaFetcher
 
-export function setLinkCreator(newLinkCreator) {
+export function setLinkCreator(
+  newLinkCreator: LinkAndSubscriptionGetter | undefined,
+) {
   if (newLinkCreator) {
     linkCreator = newLinkCreator
     schemaFetcher = new SchemaFetcher(newLinkCreator)


### PR DESCRIPTION
Fixes #981.

Changes proposed in this pull request:
- This pull request will fix bug #981 (which I reported later today). The schema-fetching failed earlier because og incorrect / missing types for createApolloLink and linkCreator in fetchingSaga.ts.
- I added a type LinkAndSubscriptionGetter (I saw that the SchemaFetcher class had a similar type LinkGetter, but that one was missing the subscriptionclient so I added a new type)
- I changed the createApolloLink signature from: (session, subscriptionEndpoint) => ApolloLink   to: (session, subscriptionEndpoint) => { link: ApolloLink, subscriptionClient?: SubscriptionClient }