### PR TITLE
:label: Add missing fields in ISetting interface for the playground-html …

### DIFF
--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -14,6 +14,7 @@ export interface MiddlewareOptions {
 
 export type CursorShape = 'line' | 'block' | 'underline'
 export type Theme = 'dark' | 'light'
+export type RequestCredentials = 'omit' | 'include' | 'same-origin'
 
 export interface ISettings {
   'general.betaUpdates': boolean
@@ -23,8 +24,17 @@ export interface ISettings {
   'tracing.hideTracingResponse': boolean
   'editor.fontSize': number
   'editor.fontFamily': string
-  'request.credentials': string
+  'request.credentials': RequestCredentials
+  'prettier.printWidth': number
+  'prettier.tabWidth': number
+  'prettier.useTabs': boolean
+  'schema.polling.enable': boolean
+  'schema.polling.endpointFilter': string
+  'schema.polling.interval': number
+  'schema.disableComments': boolean
 }
+
+
 
 export interface EditorColours {
   property: string


### PR DESCRIPTION
:label: Add missing fields in ISetting interface for the playground-html …

Fixes #996.

Changes proposed in this pull request:

- extend `ISettings` interface with missing fields

- introduce Type for RequestCredentials as mentioned in the README.md
