### PR TITLE
Adjust colours of CodeMirror "Find" dialog on "light" background.

### DIFF
--- a/packages/graphql-playground-react/src/components/Playground/EditorWrapper.tsx
+++ b/packages/graphql-playground-react/src/components/Playground/EditorWrapper.tsx
@@ -611,6 +611,15 @@ const EditorWrapper = styled.div`
     width: 20em;
   }
 
+  .CodeMirror-dialog span.CodeMirror-search-label {
+    color: ${p => p.theme.colours.text};
+  }
+
+  .CodeMirror-dialog input.CodeMirror-search-field {
+    color: ${p => p.theme.colours.text};
+    background: ${p => p.theme.colours.background};
+  }
+
   .CodeMirror-dialog button {
     font-size: 70%;
   }


### PR DESCRIPTION
This change adjusts the CSS stylings for the colours of the CodeMirror "search" dialog, which appears temporarily when pressing Ctrl-F/Cmd-F within the query or response frames of GraphQL Playground, to be visible within the light theme.  It slightly improves the visibility on the dark theme as well!

### Before

> Note, there is text there, it's just impossible to see!
<img width="747" alt="Screen Shot 2019-07-05 at 16 03 28 " src="https://user-images.githubusercontent.com/841294/60724452-22f8d680-9f3f-11e9-98d1-f57c203f3e1f.png">

### After
<img width="639" alt="Screen Shot 2019-07-05 at 16 04 26 " src="https://user-images.githubusercontent.com/841294/60724453-22f8d680-9f3f-11e9-81aa-a729d20e32ec.png">

### After Dark
<img width="619" alt="Screen Shot 2019-07-05 at 16 04 45 " src="https://user-images.githubusercontent.com/841294/60724454-23916d00-9f3f-11e9-9215-96b28655bcf9.png">


Fixes: https://github.com/apollographql/apollo-server/issues/2117