### PR TITLE
fix: add prettier.printWidth to playground settings

### DIFF
--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -24,6 +24,7 @@ export interface ISettings {
   'editor.fontSize': number
   'editor.fontFamily': string
   'request.credentials': string
+  'prettier.printWidth': number
 }
 
 export interface EditorColours {


### PR DESCRIPTION
Changes proposed in this pull request:

- add `prettier.printWidth` to TS types