### PR TITLE
Move some dependencies as devDependencies

### DIFF
--- a/packages/graphql-playground-react/package.json
+++ b/packages/graphql-playground-react/package.json
@@ -82,7 +82,9 @@
     "lint-staged": "6.1.0",
     "node-noop": "1.0.0",
     "object-assign": "4.1.1",
+    "prettier": "^1.13.0",
     "promise": "8.0.1",
+    "prop-types": "^15.6.0",
     "raw-loader": "0.5.1",
     "react-dev-utils": "5.0.2",
     "recursive-readdir": "2.2.2",
@@ -100,6 +102,7 @@
     "typescript-styled-plugin": "^0.11.0",
     "url-loader": "0.6.2",
     "webpack": "3.10.0",
+    "webpack-bundle-analyzer": "^3.3.2",
     "webpack-dev-server": "2.11.1",
     "webpack-manifest-plugin": "1.3.2",
     "why-did-you-update": "0.1.1"
@@ -126,8 +129,6 @@
     "lodash.debounce": "^4.0.8",
     "markdown-it": "^8.4.1",
     "marked": "^0.3.19",
-    "prettier": "^1.13.0",
-    "prop-types": "^15.6.0",
     "query-string": "5",
     "react": "^16.3.1",
     "react-addons-shallow-compare": "^15.6.2",
@@ -155,7 +156,6 @@
     "styled-components": "^4.0.0",
     "subscriptions-transport-ws": "^0.9.5",
     "utility-types": "^1.0.0",
-    "webpack-bundle-analyzer": "^3.3.2",
     "zen-observable": "^0.7.1"
   },
   "lint-staged": {


### PR DESCRIPTION
Fixes # NA

Changes proposed in this pull request:

Some packages should be installed as a `devDependency` and not as `dependency`. It can induce `yarn` in bad behaviors.