### PR TITLE
Update brew installation command instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive
 ## Installation
 
 ```sh
-$ brew cask install graphql-playground
+$ brew install --cask graphql-playground
 ```
 
 ## Features


### PR DESCRIPTION
Changing the `brew` installation command instruction as the existing style has been removed in Homebrew `2.7.0`.

Homebrew 2.7.0 Changelog - https://github.com/Homebrew/brew/releases/tag/2.7.0
PR concerning the deprecation - https://github.com/Homebrew/brew/pull/9247

Fixes #NA.

Changes proposed in this pull request:

- Updating the installation command instruction on README to be in sync with Homebrew changes
