### PR TITLE
docs(readme): update install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive
 ## Installation
 
 ```sh
-$ brew cask install graphql-playground
+$ brew install --cask graphql-playground
 ```
 
 ## Features


### PR DESCRIPTION
Update install command to solve the issue

> Error: Calling brew cask install is disabled! Use brew install [--cask] instead.

This is new command based on https://brew.sh/

BTW, nice tool!
