### PR TITLE
Updating brew installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive
 ## Installation
 
 ```sh
-$ brew cask install graphql-playground
+$ brew install --cask graphql-playground
 ```
 
 ## Features


### PR DESCRIPTION
Brew has deprecated and removed the `brew cask` in favor of `brew install --cask` and error out with the following error

```bash
Error: Calling brew cask install is disabled! Use brew install [--cask] instead.
```

Updating reame instruction
