### PR TITLE
Update install instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ GraphQL IDE for better development workflows (GraphQL Subscriptions, interactive
 ## Installation
 
 ```sh
-$ brew cask install graphql-playground
+$ brew install --cask graphql-playground
 ```
 
 ## Features


### PR DESCRIPTION
Changes proposed in this pull request:

- Documentation update because of brew changes:
> Warning: Calling brew cask install is deprecated! Use brew install [--cask] instead.
