### PR TITLE
docs: fix contributor code of conduct link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 [fork]: https://github.com/graphcool/graphql-playground/fork
 [pr]: https://github.com/graphcool/graphql-playground/compare
-[code-of-conduct]: CODE_OF_CONDUCT.md
+[code-of-conduct]: ../CODE_OF_CONDUCT.md
 
 Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
 


### PR DESCRIPTION
Fixes contributor code of conduct link in [CONTRIBUTING.md](https://github.com/graphql/graphql-playground/blob/2be0d9bc8070f5c9841c06d807c292f6828610f9/.github/CONTRIBUTING.md).

Changes proposed in this pull request:
- Current [Contributor Code of Conduct link](https://github.com/graphql/graphql-playground/blob/2be0d9bc8070f5c9841c06d807c292f6828610f9/.github/CONTRIBUTING.md) is broken and redirects to a 404.