### PR TITLE
fix: make Playground's middleware settings optional

### DIFF
--- a/packages/graphql-playground-html/src/render-playground-page.ts
+++ b/packages/graphql-playground-html/src/render-playground-page.ts
@@ -8,7 +8,7 @@ export interface MiddlewareOptions {
   workspaceName?: string
   env?: any
   config?: any
-  settings?: ISettings
+  settings?: Partial<ISettings>
   schema?: IntrospectionResult
   tabs?: Tab[]
   codeTheme?: EditorColours


### PR DESCRIPTION
We should be able to only set the settings that we want to set without having to give a value for every parameters.

This PR fixes that.