### PR TITLE
Add consistency with @acao political #BLM views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **Note:** The primary maintainer @acao is on hiatus until December 2020
+> # Black Lives Matter 🖤
 
 > **SECURITY WARNING:** both `graphql-playground-html` and [all four (4) of it's middleware dependents](#impacted-packages) until `graphql-playground-html@1.6.22` were subject to an  **XSS Reflection attack vulnerability only to unsanitized user input strings** to the functions therein. This was resolved in `graphql-playground-html@^1.6.22`. [More Information](#security-details) [CVE-2020-4038](https://github.com/graphql/graphql-playground/security/advisories/GHSA-4852-vrh7-28rf)
 


### PR DESCRIPTION
Personally I think open-source should be politically neutral, but since
-  @acao is the maintainer of this repo and of graphiql
- and he was against removing this phrase in graphiql https://github.com/graphql/graphiql/pull/1958
- and both repos follow GraphQL foundation
- and I am for consistency

Lets have this phrase everywhere then 🤷🏻